### PR TITLE
WIP: Fetch Emojis from Buildkite API, Theme UI

### DIFF
--- a/components/Flow/Flow.module.scss
+++ b/components/Flow/Flow.module.scss
@@ -23,6 +23,18 @@
   }
 }
 
+.logo {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  padding: 8px 8px 4px;
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(8px);
+  border-radius: 8px;
+}
+
 .controls {
   margin: 20px;
   border-radius: 10px;
@@ -39,10 +51,17 @@
     width: 24px;
     height: 24px;
     padding: 8px;
+    background: $base-0;
+    &:hover {
+      background: $gray-200;
+    }
   }
 }
 
 [data-theme="dark"] {
+  .logo {
+    background-color: rgba($slate-900, 20%);
+  }
   .flow {
     background: rgba($purple-600, 20%);
     box-shadow: inset 0px 0px 200px 50px rgba(0, 0, 0, 0.9);
@@ -63,6 +82,12 @@
     svg {
       stroke: $base-0;
       fill: $base-0;
+    }
+    button {
+      background: $slate-800;
+      &:hover {
+        background: $slate-900;
+      }
     }
   }
 }

--- a/components/Flow/Flow.module.scss
+++ b/components/Flow/Flow.module.scss
@@ -15,8 +15,11 @@
   :global(.react-flow__pane.dragging) {
     cursor: grabbing;
   }
-  :global(.react-flow__background svg) {
-    color: rgba($slate-800, 20%);
+  :global(.react-flow__background) {
+    color: rgba($slate-800, 50%);
+  }
+  :global(.react-flow__edge) {
+    color: $slate-500;
   }
 }
 
@@ -49,6 +52,10 @@
     }
     :global(.react-flow__background) {
       color: rgba($purple-600, 100%);
+      opacity: 1;
+    }
+    :global(.react-flow__edge) {
+      color: $purple-600;
     }
   }
   .controls {

--- a/components/Flow/Flow.module.scss
+++ b/components/Flow/Flow.module.scss
@@ -16,18 +16,46 @@
     cursor: grabbing;
   }
   :global(.react-flow__background svg) {
-    color: rgba($slate-800, 50%);
+    color: rgba($slate-800, 20%);
   }
 }
 
-[data-theme="dark"] .flow {
-  background: rgba($purple-600, 20%);
-  box-shadow: inset 0px 0px 200px 50px rgba(0, 0, 0, 0.9);
-  :global(.react-flow__controls-button) {
-    background: $slate-800;
-    border-bottom: 0;
+.controls {
+  margin: 20px;
+  border-radius: 10px;
+  overflow: hidden;
+  padding: 8px;
+  background: $base-0;
+  box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1),
+    0px 20px 20px rgba(0, 0, 0, 0.07), 0px 10px 20px rgba(0, 0, 0, 0.05),
+    0px 13px 18px rgba(0, 0, 0, 0.04), 0px 7px 9px rgba(0, 0, 0, 0.03);
+
+  button {
+    border: 0 none;
+    border-radius: 8px;
+    width: 24px;
+    height: 24px;
+    padding: 8px;
   }
-  :global(.react-flow__background) {
-    color: rgba($purple-600, 100%);
+}
+
+[data-theme="dark"] {
+  .flow {
+    background: rgba($purple-600, 20%);
+    box-shadow: inset 0px 0px 200px 50px rgba(0, 0, 0, 0.9);
+    :global(.react-flow__controls-button) {
+      background: $slate-800;
+      border-bottom: 0;
+    }
+    :global(.react-flow__background) {
+      color: rgba($purple-600, 100%);
+    }
+  }
+  .controls {
+    background: rgba($slate-800, 100%);
+    svg {
+      stroke: $base-0;
+      fill: $base-0;
+    }
   }
 }

--- a/components/Flow/Flow.module.scss
+++ b/components/Flow/Flow.module.scss
@@ -1,26 +1,33 @@
 @use "sass:color";
 
-@import 'styles/variables';
+@import "styles/variables";
 
 .flow {
   flex-grow: 1;
   font-size: 12px;
   cursor: pointer;
 
-  box-shadow: inset 0px 0px 200px 50px rgba(0, 0, 0, 0.9);
-
   /* ReactFlow always shows a grabby hand by default, so let's not do that unless
    * you're trying to drag the canvas around */
-  :global(.react-flow__pane) { cursor: default; }
-  :global(.react-flow__pane.dragging) { cursor: grabbing; }
+  :global(.react-flow__pane) {
+    cursor: default;
+  }
+  :global(.react-flow__pane.dragging) {
+    cursor: grabbing;
+  }
+  :global(.react-flow__background svg) {
+    color: rgba($slate-800, 50%);
+  }
 }
 
-[data-theme='dark'] .flow {
+[data-theme="dark"] .flow {
   background: rgba($purple-600, 20%);
-
+  box-shadow: inset 0px 0px 200px 50px rgba(0, 0, 0, 0.9);
   :global(.react-flow__controls-button) {
     background: $slate-800;
     border-bottom: 0;
   }
+  :global(.react-flow__background) {
+    color: rgba($purple-600, 100%);
+  }
 }
-

--- a/components/Flow/GroupStepNode.js
+++ b/components/Flow/GroupStepNode.js
@@ -1,16 +1,59 @@
-import { memo } from 'react';
-import { Handle, Position } from 'reactflow';
-import classNames from 'classnames';
+import { memo } from "react";
+import { Handle, Position } from "reactflow";
+import classNames from "classnames";
+import Label from "./Label";
+import styles from "./GroupStepNode.module.scss";
 
-import styles from './GroupStepNode.module.scss';
+const Curve = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="10"
+    height="10"
+    fill="none"
+    viewBox="0 0 10 10"
+  >
+    <path
+      fill="currentColor"
+      fillRule="evenodd"
+      d="M10 0H0v10C0 4.477 4.477 0 10 0z"
+      clipRule="evenodd"
+    ></path>
+  </svg>
+);
 
-const GroupStepNode = ({ id, data, sourcePosition, targetPosition, selected }) => {
+const GroupStepNode = ({
+  id,
+  data,
+  sourcePosition,
+  targetPosition,
+  selected,
+}) => {
   return (
     <>
-      <div className={classNames("GroupStepDragHandle", styles.label)}>{data.label}</div>
-      <div className={classNames(styles.container, { [ styles.selected ]: selected })}></div>
-      <Handle id={id} type="target" position={targetPosition} className={styles.handle} isConnectable={false} />
-      <Handle id={id} type="source" position={sourcePosition} className={styles.handle} isConnectable={false} />
+      <div className={classNames("GroupStepDragHandle", styles.label)}>
+        <Label>{data.label}</Label>
+        <Curve />
+        <Curve />
+      </div>
+      <div
+        className={classNames(styles.container, {
+          [styles.selected]: selected,
+        })}
+      ></div>
+      <Handle
+        id={id}
+        type="target"
+        position={targetPosition}
+        className={styles.handle}
+        isConnectable={false}
+      />
+      <Handle
+        id={id}
+        type="source"
+        position={sourcePosition}
+        className={styles.handle}
+        isConnectable={false}
+      />
     </>
   );
 };

--- a/components/Flow/GroupStepNode.module.scss
+++ b/components/Flow/GroupStepNode.module.scss
@@ -50,13 +50,6 @@
 }
 
 [data-theme="dark"] {
-  .label {
-    background: rgba($purple-600, 100%);
-    color: $slate-500;
-    svg {
-      color: rgba($purple-600, 100%);
-    }
-  }
   .container {
     border: 2px solid rgba($purple-600, 100%);
     background: rgba($purple-600, 10%);

--- a/components/Flow/GroupStepNode.module.scss
+++ b/components/Flow/GroupStepNode.module.scss
@@ -1,16 +1,17 @@
 @use "sass:color";
 
-@import 'styles/variables';
+@import "styles/variables";
 
 .container {
-  border: 2px solid rgba($green-400, 50%);
+  border: 2px solid rgba($purple-600, 100%);
+  background: rgba($purple-100, 100%);
+  margin-top: -40px;
+  margin-bottom: -40px;
 
   width: 100%;
-  height: 100%;
+  height: calc(100% + 40px);
 
-  border-top-right-radius: 8px;
-  border-bottom-left-radius: 8px;
-  border-bottom-right-radius: 8px;
+  border-radius: 8px;
 
   cursor: default;
 }
@@ -19,21 +20,46 @@
   position: absolute;
   top: 0px;
   left: 0;
-  color: $slate-500;
-  transform: translate(0px, -100%);
+  color: $base-0;
   height: $grid-size * 2;
   display: flex;
   align-items: center;
+  border-radius: 8px 0 10px 0;
+  transform: translateY(-100%);
 
-  border: 2px solid rgba($green-400, 50%);
+  border: 0 none;
   border-bottom-width: 0;
 
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-
-  background: rgba($slate-900, 60%);
+  background: rgba($purple-600, 100%);
   padding: 0px 10px;
   font-size: 13px;
   white-space: nowrap;
   font-weight: 500;
+  svg {
+    color: rgba($purple-600, 100%);
+    position: absolute;
+  }
+  svg:nth-child(2) {
+    right: -10px;
+    top: 2px;
+  }
+  svg:nth-child(3) {
+    left: 2px;
+    top: 40px;
+  }
+}
+
+[data-theme="dark"] {
+  .label {
+    background: rgba($purple-600, 100%);
+    color: $slate-500;
+    svg {
+      color: rgba($purple-600, 100%);
+    }
+  }
+  .container {
+    border: 2px solid rgba($purple-600, 100%);
+    background: rgba($purple-600, 10%);
+    border-radius: 10px;
+  }
 }

--- a/components/Flow/GroupStepNode.module.scss
+++ b/components/Flow/GroupStepNode.module.scss
@@ -41,11 +41,11 @@
   }
   svg:nth-child(2) {
     right: -10px;
-    top: 2px;
+    top: 1px;
   }
   svg:nth-child(3) {
     left: 2px;
-    top: 40px;
+    top: 39px;
   }
 }
 

--- a/components/Flow/Label.js
+++ b/components/Flow/Label.js
@@ -1,0 +1,30 @@
+import { useContext } from "react";
+import { EmojiContext } from "../../context/EmojiContext";
+
+function emojify(text, emojis) {
+  return text.replace(/:([\w+-]+):/gm, function (original, name) {
+    if (emojis[name]) {
+      return (
+        '<img width="16" class="emoji" src="' +
+        emojis[name] +
+        '" alt="' +
+        name +
+        '">'
+      );
+    } else {
+      return original;
+    }
+  });
+}
+
+const Label = ({ children }) => {
+  const emoji = useContext(EmojiContext);
+  return (
+    <div
+      style={{ display: "flex", alignItems: "center", gap: 5 }}
+      dangerouslySetInnerHTML={{ __html: emojify(children, emoji) }}
+    />
+  );
+};
+
+export default Label;

--- a/components/Flow/SectionNode.js
+++ b/components/Flow/SectionNode.js
@@ -1,19 +1,21 @@
-import { memo, useRef, useEffect } from 'react';
-import { makeMoveable, Draggable, Resizable, } from 'react-moveable';
-import styles from './SectionNode.module.scss';
-import useStore from './store';
-import { GRID_SPACE } from './constants';
-import { GithubPicker } from 'react-color';
+import { memo, useRef, useEffect } from "react";
+import { makeMoveable, Draggable, Resizable } from "react-moveable";
+import styles from "./SectionNode.module.scss";
+import useStore from "./store";
+import { GRID_SPACE } from "./constants";
+import { GithubPicker } from "react-color";
 
 const Moveable = makeMoveable([Draggable, Resizable]);
 
-const SectionNode = ({ id, data, selected, dragging }) => {
+const SectionNode = ({ id, data, selected, dragging, emoji }) => {
   const resizeRef = useRef(null);
   const nodeElementRef = useRef(null);
   const moveableRef = useRef(null);
 
   useEffect(() => {
-    nodeElementRef.current = document.querySelector(`.react-flow__node[data-id="${id}"]`);
+    nodeElementRef.current = document.querySelector(
+      `.react-flow__node[data-id="${id}"]`
+    );
   }, [id]);
 
   useEffect(() => {
@@ -32,31 +34,34 @@ const SectionNode = ({ id, data, selected, dragging }) => {
     }
 
     event.delta[0] && (nodeElementRef.current.style.width = `${event.width}px`);
-    event.delta[1] && (nodeElementRef.current.style.height = `${event.height}px`);
+    event.delta[1] &&
+      (nodeElementRef.current.style.height = `${event.height}px`);
 
     updateNodePosition(id, ({ position }) => {
       return {
         x: event.direction[0] === -1 ? position.x - event.delta[0] : position.x,
         y: event.direction[1] === -1 ? position.y - event.delta[1] : position.y,
-      }
+      };
     });
   };
 
   const onResizeEnd = (event) => {
-    if (!nodeElementRef.current) { return; }
+    if (!nodeElementRef.current) {
+      return;
+    }
 
     updateNodeStyle(id, ({ style }) => {
       return {
         ...style,
         width: nodeElementRef.current.style.width,
         height: nodeElementRef.current.style.height,
-      }
+      };
     });
-  }
+  };
 
   const onColorChange = (event) => {
     updateNodeData(id, ({ data }) => {
-      return { color: event.hex }
+      return { color: event.hex };
     });
   };
 
@@ -76,10 +81,14 @@ const SectionNode = ({ id, data, selected, dragging }) => {
         throttleResize={GRID_SPACE}
       />
 
-      <div className={styles.container} ref={resizeRef} style={{backgroundColor: data.color}}>
+      <div
+        className={styles.container}
+        ref={resizeRef}
+        style={{ backgroundColor: data.color }}
+      >
         <div
           className={styles.toolbar}
-          style={{display: (selected && !dragging ? 'block' : 'none')}}
+          style={{ display: selected && !dragging ? "block" : "none" }}
         >
           <button>Color</button>
           <div className={styles.colorPicker}>

--- a/components/Flow/SectionNode.module.scss
+++ b/components/Flow/SectionNode.module.scss
@@ -3,7 +3,7 @@
   width: 100%;
   height: 100%;
   border-radius: 5px;
-  border: 1px solid var(--red-700);;
+  border: 1px solid var(--red-700);
   background: var(--red-100);
   z-index: 100;
 }
@@ -13,7 +13,7 @@
   top: -30px;
   left: 0;
   color: var(--red-500);
-  border: 1px solid var(--red-700);;
+  border: 1px solid var(--red-700);
   background: var(--red-100);
   border-radius: 4px;
   font-weight: bold;
@@ -35,4 +35,11 @@
   position: absolute;
   bottom: 0px;
   transform: translate(0, 130%);
+}
+
+[data-theme="dark"] {
+  .container {
+    border: 1px solid var(--red-700);
+    background: var(--red-100);
+  }
 }

--- a/components/Flow/StepNode.js
+++ b/components/Flow/StepNode.js
@@ -1,19 +1,43 @@
-import { memo } from 'react';
-import { Handle, Position } from 'reactflow';
-import classNames from 'classnames';
+import { memo } from "react";
+import { Handle, Position } from "reactflow";
+import classNames from "classnames";
+import Label from "./Label";
 
-import styles from './StepNode.module.scss';
+import styles from "./StepNode.module.scss";
 
-const StepNode = ({ id, data, x, y, sourcePosition, targetPosition, selected }) => {
+const StepNode = ({
+  id,
+  data,
+  x,
+  y,
+  sourcePosition,
+  targetPosition,
+  selected,
+  emoji,
+}) => {
   return (
     <>
-      <div className={classNames(styles.default, { [ styles.selected ]: selected })}>
-        <div>{data.label}</div>
+      <div
+        className={classNames(styles.default, { [styles.selected]: selected })}
+      >
+        <Label emoji={emoji}>{data.label}</Label>
         <div className={styles.elapsed}>4m 39s</div>
       </div>
 
-      <Handle id={id} type="target" position={targetPosition} className={styles.handle} isConnectable={false} />
-      <Handle id={id} type="source" position={sourcePosition} className={styles.handle} isConnectable={false} />
+      <Handle
+        id={id}
+        type="target"
+        position={targetPosition}
+        className={styles.handle}
+        isConnectable={false}
+      />
+      <Handle
+        id={id}
+        type="source"
+        position={sourcePosition}
+        className={styles.handle}
+        isConnectable={false}
+      />
     </>
   );
 };

--- a/components/Flow/StepNode.module.scss
+++ b/components/Flow/StepNode.module.scss
@@ -2,7 +2,7 @@
 
 @import "styles/variables";
 
-$height: $grid-size * 3;
+$height: 46px;
 
 .default {
   background-color: rgba($base-0, 100%);
@@ -17,12 +17,19 @@ $height: $grid-size * 3;
   align-items: center;
   height: $height;
   width: 100%;
+  box-sizing: border-box;
   transition-property: transform, background-color, box-shadow, color,
     border-color;
   transition-duration: 0.1s;
   backdrop-filter: blur(2px);
-  box-shadow: 0px 20px 20px rgb(0 0 0 / 7%), 0px 10px 20px rgb(0 0 0 / 5%),
-    0px 13px 18px rgb(0 0 0 / 4%), 0px 7px 9px rgb(0 0 0 / 3%);
+  box-shadow: 0px 0px 0px 0 rgba(0, 190, 19, 0);
+  position: relative;
+}
+
+.selected {
+  color: $charcoal-800;
+  border: 2px solid $green-500;
+  box-shadow: 0px 0px 0px 4px rgba(0, 190, 19, 0.2);
 }
 
 :global(.dragging) .default {
@@ -42,26 +49,36 @@ $height: $grid-size * 3;
   background: $slate-100;
   position: absolute;
   bottom: 0;
-  left: 5px;
-  border-radius: 10px;
-  padding: 0 8px;
-  transform: translate(0, 50%);
+  left: -2px;
+  border-radius: 0 0 4px 4px;
+  padding: 0 8px 0;
+  transform: translate(0, 100%);
   font-family: SFMono-Regular, Monaco, Menlo, Consolas, Liberation Mono, Courier,
     monospace;
   font-size: 11px;
   font-weight: 500;
   line-height: $grid-size;
   color: $slate-900;
-  transition-property: background-color, color;
+  transition-property: background-color, color, opacity;
   transition-duration: 0.1s;
-  box-shadow: 0px 0px 0px 1px rgb(0 0 0 / 10%), 0px 20px 20px rgb(0 0 0 / 7%),
-    0px 10px 20px rgb(0 0 0 / 5%), 0px 13px 18px rgb(0 0 0 / 4%),
-    0px 7px 9px rgb(0 0 0 / 3%);
+  opacity: 0;
+  box-sizing: border-box;
+  &:before {
+    content: "";
+    display: block;
+    position: absolute;
+    width: 5px;
+    height: 8px;
+    top: -8px;
+    left: 0;
+    background-image: url("data:image/svg+xml,%3Csvg width='5' height='8' viewBox='0 0 5 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M2 0H0V8H5V7.87399C3.27478 7.42996 2 5.86383 2 4V0Z' fill='%2300BE13'/%3E%3C/svg%3E%0A");
+  }
 }
 
 .selected .elapsed {
-  background: $green-400;
+  background: $green-500;
   color: $slate-900;
+  opacity: 1;
 }
 
 :export {
@@ -89,7 +106,7 @@ $height: $grid-size * 3;
     background: $slate-800;
   }
   .selected .elapsed {
-    background: $green-400;
+    background: $green-500;
     color: $slate-900;
   }
 }

--- a/components/Flow/StepNode.module.scss
+++ b/components/Flow/StepNode.module.scss
@@ -1,14 +1,15 @@
 @use "sass:color";
 
-@import 'styles/variables';
+@import "styles/variables";
 
 $height: $grid-size * 3;
 
 .default {
-  background-color: rgba($slate-900, 60%);
-  border: 2px solid rgba($green-500, 50%);
-  color: $slate-500;
-  font-size: 14px;
+  background-color: rgba($base-0, 100%);
+  border: 2px solid rgba($green-400, 100%);
+  color: $charcoal-700;
+  font-size: 13px;
+  letter-spacing: 0.25px;
   font-weight: 500;
   padding: 0 15px 0 10px;
   border-radius: 8px;
@@ -16,22 +17,17 @@ $height: $grid-size * 3;
   align-items: center;
   height: $height;
   width: 100%;
-  transition-property: transform, background-color, box-shadow, color, border-color;
+  transition-property: transform, background-color, box-shadow, color,
+    border-color;
   transition-duration: 0.1s;
   backdrop-filter: blur(2px);
-  box-shadow: 0px 20px 20px rgb(0 0 0 / 7%), 0px 10px 20px rgb(0 0 0 / 5%), 0px 13px 18px rgb(0 0 0 / 4%), 0px 7px 9px rgb(0 0 0 / 3%);
+  box-shadow: 0px 20px 20px rgb(0 0 0 / 7%), 0px 10px 20px rgb(0 0 0 / 5%),
+    0px 13px 18px rgb(0 0 0 / 4%), 0px 7px 9px rgb(0 0 0 / 3%);
 }
 
 :global(.dragging) .default {
   /* Making it a bit bigger when dragging is nice and fun, but needs more tweaking */
   /* transform: scale(1.5) translate(0px,0px); */
-}
-
-[data-theme='dark'] .selected {
-  background-color: $slate-900;
-  border-color: $green-500;
-  color: $base-0;
-  box-shadow: 0px 22px 50px 5px rgb(45 255 67 / 20%), 0px 12px 20px rgb(45 255 67 / 15%), 0px 7px 10px rgb(45 255 67 / 15%), 0px 5px 4px rgb(45 255 67 / 5%)
 }
 
 .handle {
@@ -43,21 +39,24 @@ $height: $grid-size * 3;
 }
 
 .elapsed {
-  background: $slate-800;
+  background: $slate-100;
   position: absolute;
   bottom: 0;
   left: 5px;
   border-radius: 10px;
   padding: 0 8px;
   transform: translate(0, 50%);
-  font-family: SFMono-Regular,Monaco,Menlo,Consolas,Liberation Mono,Courier,monospace;
+  font-family: SFMono-Regular, Monaco, Menlo, Consolas, Liberation Mono, Courier,
+    monospace;
   font-size: 11px;
   font-weight: 500;
   line-height: $grid-size;
-  color: $slate-500;
+  color: $slate-900;
   transition-property: background-color, color;
   transition-duration: 0.1s;
-  box-shadow: 0px 0px 0px 1px rgb(0 0 0 / 10%), 0px 20px 20px rgb(0 0 0 / 7%), 0px 10px 20px rgb(0 0 0 / 5%), 0px 13px 18px rgb(0 0 0 / 4%), 0px 7px 9px rgb(0 0 0 / 3%)
+  box-shadow: 0px 0px 0px 1px rgb(0 0 0 / 10%), 0px 20px 20px rgb(0 0 0 / 7%),
+    0px 10px 20px rgb(0 0 0 / 5%), 0px 13px 18px rgb(0 0 0 / 4%),
+    0px 7px 9px rgb(0 0 0 / 3%);
 }
 
 .selected .elapsed {
@@ -67,4 +66,30 @@ $height: $grid-size * 3;
 
 :export {
   height: $height;
+}
+
+[data-theme="dark"] {
+  .default {
+    background-color: rgba($slate-900, 60%);
+    border: 2px solid rgba($green-500, 50%);
+    color: $slate-500;
+    box-shadow: 0px 20px 20px rgb(0 0 0 / 7%), 0px 10px 20px rgb(0 0 0 / 5%),
+      0px 13px 18px rgb(0 0 0 / 4%), 0px 7px 9px rgb(0 0 0 / 3%);
+  }
+  .selected {
+    background-color: $slate-900;
+    border-color: $green-500;
+    color: $base-0;
+    box-shadow: 0px 22px 50px 5px rgb(45 255 67 / 20%),
+      0px 12px 20px rgb(45 255 67 / 15%), 0px 7px 10px rgb(45 255 67 / 15%),
+      0px 5px 4px rgb(45 255 67 / 5%);
+  }
+  .elapsed {
+    color: $slate-500;
+    background: $slate-800;
+  }
+  .selected .elapsed {
+    background: $green-400;
+    color: $slate-900;
+  }
 }

--- a/components/Flow/Toolbar.js
+++ b/components/Flow/Toolbar.js
@@ -1,0 +1,92 @@
+import styles from "./Toolbar.module.scss";
+
+const Svg = ({ children, active }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="36"
+    height="36"
+    fill="none"
+    viewBox="0 0 36 36"
+    className={(active) ? styles.activeicon : styles.icon}
+  >
+    {children}
+  </svg>
+)
+
+const MoveIcon = ({ active = false }) => (
+  <Svg active={active}>
+    <rect
+      width="14"
+      height="18"
+      x="11"
+      y="9"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      rx="6"
+    />
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+      d="M18 16v-3"
+    />
+  </Svg>
+)
+
+const NewSectionIcon = ({ active = false }) => (
+  <Svg active={active}>
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+      d="M18 15v6M21 18h-6"
+    />
+    <rect
+      width="18"
+      height="18"
+      x="9"
+      y="9"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      rx="4"
+    />
+  </Svg>
+)
+
+const EmojiIcon = ({ active = false }) => (
+  <Svg active={active}>
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+      d="M18 28c5.523 0 10-4.477 10-10S23.523 8 18 8 8 12.477 8 18s4.477 10 10 10z"
+    />
+    <path
+      fill="currentColor"
+      d="M14.5 16a1.5 1.5 0 100-3 1.5 1.5 0 000 3zM21.5 16a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"
+    />
+    <path
+      fill="currentColor"
+      fillRule="evenodd"
+      d="M13 19c.833 2.667 2.5 4 5 4s4.167-1.333 5-4H13z"
+      clipRule="evenodd"
+    />
+  </Svg>
+)
+
+const Toolbar = () => (
+  <div className={styles.container}>
+    <div className={styles.main}>
+      <MoveIcon active />
+      <NewSectionIcon />
+      <EmojiIcon />
+    </div>
+    <div className={styles.theme}>
+    </div>
+  </div>
+)
+
+export default Toolbar

--- a/components/Flow/Toolbar.module.scss
+++ b/components/Flow/Toolbar.module.scss
@@ -1,0 +1,44 @@
+@use "sass:color";
+
+@import "styles/variables";
+
+.container {
+  background: $base-0;
+  box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px 20px 20px rgba(0, 0, 0, 0.07), 0px 10px 20px rgba(0, 0, 0, 0.05), 0px 13px 18px rgba(0, 0, 0, 0.04), 0px 7px 9px rgba(0, 0, 0, 0.03);
+  border-radius: 20px;
+  position: fixed;
+  bottom: 20px;
+  padding: 20px 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+}
+
+.main {
+  display: flex;
+  gap: 8px;
+}
+
+.theme {
+  display: flex;
+  gap: 8px;
+}
+
+
+.icon {
+  border-radius: 8px;
+  color: #202632;
+}
+
+.activeicon {
+  background: linear-gradient(0deg, #4B19D5 0%, #7939FF 100%);
+  border-radius: 8px;
+  color: #fff;
+}
+
+[data-theme="dark"] .container {
+  background: $slate-800;
+  .icon {
+    color: $base-0;
+  }
+}

--- a/components/Flow/index.js
+++ b/components/Flow/index.js
@@ -90,7 +90,11 @@ function Flow({ roomId, initialNodes, initialEdges }) {
           size={1}
           color="currentColor"
         />
-        <Controls showInteractive={false} />
+        <Controls
+          showInteractive={false}
+          position="top-left"
+          className={styles.controls}
+        />
       </ReactFlow>
     </div>
   );

--- a/components/Flow/index.js
+++ b/components/Flow/index.js
@@ -28,7 +28,10 @@ const defaultEdgeOptions = {
   pathOptions: { borderRadius: 40 },
   // default: purple-600
   // selected: yellow-500
-  style: { stroke: "#4b19d5", strokeWidth: 2 },
+  style: {
+    stroke: "currentColor",
+    strokeWidth: 2,
+  },
 };
 
 const proOptions = {
@@ -42,6 +45,47 @@ const proOptions = {
 const fitViewOptions = {
   maxZoom: 1,
 };
+
+const Logo = () => (
+  <svg
+    width="28"
+    height="19"
+    viewBox="0 0 28 19"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    style={{
+      position: "absolute",
+      top: "24px",
+      left: "50%",
+      transform: "translateX(-50%);",
+      zIndex: 1000,
+    }}
+  >
+    <g clip-path="url(#clip0_76_31873)">
+      <path
+        d="M0 0V4.66667V9.33333L9.33333 14V9.33333V4.66667L0 0Z"
+        fill="#30F2A2"
+      />
+      <path
+        d="M18.6667 0V4.66667V9.33333L28.0001 4.66667L18.6667 0Z"
+        fill="#30F2A2"
+      />
+      <path
+        d="M18.667 9.33333V14V18.6667L28.0003 14V9.33333V4.66667L18.667 9.33333Z"
+        fill="#14CC80"
+      />
+      <path
+        d="M9.3335 4.66667V9.33333V14L18.6668 9.33333V4.66667V0L9.3335 4.66667Z"
+        fill="#14CC80"
+      />
+    </g>
+    <defs>
+      <clipPath id="clip0_76_31873">
+        <rect width="28" height="18.6667" />
+      </clipPath>
+    </defs>
+  </svg>
+);
 
 function Flow({ roomId, initialNodes, initialEdges }) {
   const [nodes, setNodes] = useState(initialNodes);
@@ -59,6 +103,7 @@ function Flow({ roomId, initialNodes, initialEdges }) {
 
   return (
     <div className={styles.flow}>
+      <Logo />
       <ReactFlow
         defaultNodes={nodes}
         // onNodesChange={onNodesChange}
@@ -83,6 +128,7 @@ function Flow({ roomId, initialNodes, initialEdges }) {
         fitView
         maxZoom={1}
         fitViewOptions={fitViewOptions}
+        defaultZoom={1}
       >
         <Background
           variant="dots"

--- a/components/Flow/index.js
+++ b/components/Flow/index.js
@@ -13,6 +13,7 @@ import styles from "./Flow.module.scss";
 import SectionNode from "./SectionNode";
 import StepNode from "./StepNode";
 import GroupStepNode from "./GroupStepNode";
+import Toolbar from "./Toolbar";
 import { GRID_SPACE } from "./constants";
 
 // our custom node types
@@ -136,6 +137,7 @@ function Flow({ roomId, initialNodes, initialEdges }) {
           position="top-left"
           className={styles.controls}
         />
+        <Toolbar />
       </ReactFlow>
     </div>
   );

--- a/components/Flow/index.js
+++ b/components/Flow/index.js
@@ -47,44 +47,39 @@ const fitViewOptions = {
 };
 
 const Logo = () => (
-  <svg
-    width="28"
-    height="19"
-    viewBox="0 0 28 19"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    style={{
-      position: "absolute",
-      top: "24px",
-      left: "50%",
-      transform: "translateX(-50%);",
-      zIndex: 1000,
-    }}
-  >
-    <g clip-path="url(#clip0_76_31873)">
-      <path
-        d="M0 0V4.66667V9.33333L9.33333 14V9.33333V4.66667L0 0Z"
-        fill="#30F2A2"
-      />
-      <path
-        d="M18.6667 0V4.66667V9.33333L28.0001 4.66667L18.6667 0Z"
-        fill="#30F2A2"
-      />
-      <path
-        d="M18.667 9.33333V14V18.6667L28.0003 14V9.33333V4.66667L18.667 9.33333Z"
-        fill="#14CC80"
-      />
-      <path
-        d="M9.3335 4.66667V9.33333V14L18.6668 9.33333V4.66667V0L9.3335 4.66667Z"
-        fill="#14CC80"
-      />
-    </g>
-    <defs>
-      <clipPath id="clip0_76_31873">
-        <rect width="28" height="18.6667" />
-      </clipPath>
-    </defs>
-  </svg>
+  <div className={styles.logo}>
+    <svg
+      width="28"
+      height="19"
+      viewBox="0 0 28 19"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g clip-path="url(#clip0_76_31873)">
+        <path
+          d="M0 0V4.66667V9.33333L9.33333 14V9.33333V4.66667L0 0Z"
+          fill="#30F2A2"
+        />
+        <path
+          d="M18.6667 0V4.66667V9.33333L28.0001 4.66667L18.6667 0Z"
+          fill="#30F2A2"
+        />
+        <path
+          d="M18.667 9.33333V14V18.6667L28.0003 14V9.33333V4.66667L18.667 9.33333Z"
+          fill="#14CC80"
+        />
+        <path
+          d="M9.3335 4.66667V9.33333V14L18.6668 9.33333V4.66667V0L9.3335 4.66667Z"
+          fill="#14CC80"
+        />
+      </g>
+      <defs>
+        <clipPath id="clip0_76_31873">
+          <rect width="28" height="18.6667" />
+        </clipPath>
+      </defs>
+    </svg>
+  </div>
 );
 
 function Flow({ roomId, initialNodes, initialEdges }) {

--- a/components/Flow/index.js
+++ b/components/Flow/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from "react";
 import ReactFlow, {
   useNodesState,
   useEdgesState,
@@ -7,13 +7,13 @@ import ReactFlow, {
   ConnectionLineType,
   Background,
   Controls,
-} from 'reactflow';
-import useStore from './store';
-import styles from './Flow.module.scss';
-import SectionNode from './SectionNode';
-import StepNode from './StepNode';
-import GroupStepNode from './GroupStepNode';
-import { GRID_SPACE } from './constants';
+} from "reactflow";
+import useStore from "./store";
+import styles from "./Flow.module.scss";
+import SectionNode from "./SectionNode";
+import StepNode from "./StepNode";
+import GroupStepNode from "./GroupStepNode";
+import { GRID_SPACE } from "./constants";
 
 // our custom node types
 const nodeTypes = {
@@ -24,24 +24,24 @@ const nodeTypes = {
 
 const defaultEdgeOptions = {
   // animated: true,
-  type: 'smoothstep',
+  type: "smoothstep",
   pathOptions: { borderRadius: 40 },
   // default: purple-600
   // selected: yellow-500
-  style: { stroke: '#4b19d5', strokeWidth: 2 }
+  style: { stroke: "#4b19d5", strokeWidth: 2 },
 };
 
 const proOptions = {
   // passing in the account property will enable hiding the attribution
-  account: 'paid-pro',
+  account: "paid-pro",
 
   // in combination with the account property, hideAttribution: true will remove the attribution
-  hideAttribution: true
-}
+  hideAttribution: true,
+};
 
 const fitViewOptions = {
-  maxZoom: 1
-}
+  maxZoom: 1,
+};
 
 function Flow({ roomId, initialNodes, initialEdges }) {
   const [nodes, setNodes] = useState(initialNodes);
@@ -66,32 +66,30 @@ function Flow({ roomId, initialNodes, initialEdges }) {
         nodeTypes={nodeTypes}
         defaultEdgeOptions={defaultEdgeOptions}
         connectionLineType={ConnectionLineType.SmoothStep}
-
         // Only drag when space bar is pressed
-        panOnDrag={useKeyPress('Space')}
-
+        panOnDrag={useKeyPress("Space")}
         // Pan on scroll wheel
         panOnScroll
-
         proOptions={proOptions}
-
         // Snap dragging to our grid
         snapToGrid
         snapGrid={[GRID_SPACE, GRID_SPACE]}
-
         // Don't allow new connections to be made
         nodesConnectable={false}
-
         // Turn off tab to focus (for now). Handles are showing up as little blue
         // circles and I don't know how to turn them ofq
         nodesFocusable={false}
         edgesFocusable={false}
-
         fitView
         maxZoom={1}
         fitViewOptions={fitViewOptions}
       >
-        <Background variant="dots" gap={GRID_SPACE} size={1} />
+        <Background
+          variant="dots"
+          gap={GRID_SPACE}
+          size={1}
+          color="currentColor"
+        />
         <Controls showInteractive={false} />
       </ReactFlow>
     </div>

--- a/components/ThemeSwitch/ThemeSwitch.module.scss
+++ b/components/ThemeSwitch/ThemeSwitch.module.scss
@@ -1,7 +1,37 @@
+@use "sass:color";
+
+@import "styles/variables";
+
 .container {
   position: fixed;
   top: 0px;
   right: 0px;
-  margin: 15px;
+  margin: 20px;
   z-index: 5;
+  border-radius: 10px;
+  box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1),
+    0px 20px 20px rgba(0, 0, 0, 0.07), 0px 10px 20px rgba(0, 0, 0, 0.05),
+    0px 13px 18px rgba(0, 0, 0, 0.04), 0px 7px 9px rgba(0, 0, 0, 0.03);
+  select {
+    appearance: none;
+    border-radius: 10px;
+    overflow: hidden;
+    padding: 12px 24px;
+    min-width: 100px;
+    display: block;
+    background: $base-0;
+    border: 0 none;
+    font-size: 13px;
+    font-weight: 500;
+    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+      Helvetica Neue, Helvetica, sans-serif;
+    letter-spacing: 0.25;
+    outline: none;
+  }
+}
+
+[data-theme="dark"] {
+  .container select {
+    background: $slate-800;
+  }
 }

--- a/context/EmojiContext.js
+++ b/context/EmojiContext.js
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const EmojiContext = createContext({});

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,426 +1,440 @@
-import Head from 'next/head'
-import { useTheme } from 'next-themes'
-import styles from '../styles/Home.module.css'
+import Head from "next/head";
+import { useTheme } from "next-themes";
+import styles from "../styles/Home.module.css";
+import React, { useEffect } from "react";
+import { EmojiContext } from "../context/EmojiContext";
 
-import Flow from 'components/Flow';
-import ThemeSwitch from 'components/ThemeSwitch';
+import Flow from "components/Flow";
+import ThemeSwitch from "components/ThemeSwitch";
 
-import { generateGraphFromBuildSteps } from 'utils/graph';
+import { generateGraphFromBuildSteps } from "utils/graph";
 
 const response = {
-  "data": {
-    "build": {
-      "message": "Merge pull request #10001 from buildkite/fdn-1119-update-pwned-gem-and-ensure-were\n\nConfigure pwned with timeout",
-      "steps": {
-        "edges": [
+  data: {
+    build: {
+      message:
+        "Merge pull request #10001 from buildkite/fdn-1119-update-pwned-gem-and-ensure-were\n\nConfigure pwned with timeout",
+      steps: {
+        edges: [
           {
-            "node": {
-              "__typename": "StepCommand",
-              "uuid": "01836784-c4c2-47d3-b777-686384af5a8b",
-              "label": ":pipeline: Upload Pipeline",
-              "key": null,
-              "dependencies": {
-                "edges": [
-
-                ]
-              }
-            }
-          },
-          {
-            "node": {
-              "__typename": "StepCommand",
-              "uuid": "01836784-ffb1-425e-a85e-a84be7ce1295",
-              "label": ":docker: Build Docker Image",
-              "key": "docker",
-              "dependencies": {
-                "edges": [
-                  {
-                    "node": {
-                      "uuid": "9657f88d-2a93-4f24-b264-7c5a0408f96d",
-                      "allow_failure": false,
-                      "key": "01836784-c4c2-47d3-b777-686384af5a8b"
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "node": {
-              "__typename": "StepGroup",
-              "uuid": "01836784-ffb2-4e03-8797-5971abf7b4dd",
-              "label": ":broom: Linting",
-              "key": "linting",
-              "dependencies": {
-                "edges": [
-                  {
-                    "node": {
-                      "uuid": "ee5e5367-df13-4b02-8118-c3c28d54cd7a",
-                      "allow_failure": false,
-                      "key": "docker"
-                    }
-                  }
-                ]
+            node: {
+              __typename: "StepCommand",
+              uuid: "01836784-c4c2-47d3-b777-686384af5a8b",
+              label: ":pipeline: Upload Pipeline",
+              key: null,
+              dependencies: {
+                edges: [],
               },
-              "steps": {
-                "edges": [
-                  {
-                    "node": {
-                      "__typename": "StepCommand",
-                      "uuid": "01836784-ffb2-4d4e-8ae8-3b9191403a0f",
-                      "label": ":rubocop: RuboCop",
-                      "key": null,
-                      "dependencies": {
-                        "edges": [
-
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "node": {
-                      "__typename": "StepCommand",
-                      "uuid": "01836784-ffb3-4d2e-8af1-f9c8ddb60b20",
-                      "label": ":eslint: ESlint",
-                      "key": null,
-                      "dependencies": {
-                        "edges": [
-
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "node": {
-                      "__typename": "StepCommand",
-                      "uuid": "01836784-ffb3-4c5d-b540-b1b0bc04f672",
-                      "label": ":flowtype: Flow",
-                      "key": null,
-                      "dependencies": {
-                        "edges": [
-
-                        ]
-                      }
-                    }
-                  }
-                ]
-              }
-            }
+            },
           },
           {
-            "node": {
-              "__typename": "StepGroup",
-              "uuid": "01836784-ffb4-4f78-b23c-0779ee1c61f7",
-              "label": ":lock_with_ink_pen: Security Audits",
-              "key": "security_audits",
-              "dependencies": {
-                "edges": [
+            node: {
+              __typename: "StepCommand",
+              uuid: "01836784-ffb1-425e-a85e-a84be7ce1295",
+              label: ":docker: Build Docker Image",
+              key: "docker",
+              dependencies: {
+                edges: [
                   {
-                    "node": {
-                      "uuid": "ecff6fbe-aabf-4d2e-a125-d76047c4e007",
-                      "allow_failure": false,
-                      "key": "docker"
-                    }
-                  }
-                ]
+                    node: {
+                      uuid: "9657f88d-2a93-4f24-b264-7c5a0408f96d",
+                      allow_failure: false,
+                      key: "01836784-c4c2-47d3-b777-686384af5a8b",
+                    },
+                  },
+                ],
               },
-              "steps": {
-                "edges": [
-                  {
-                    "node": {
-                      "__typename": "StepCommand",
-                      "uuid": "01836784-ffb4-45d0-8a95-1f51477e1c8a",
-                      "label": ":brakeman: Brakeman",
-                      "key": null,
-                      "dependencies": {
-                        "edges": [
-
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "node": {
-                      "__typename": "StepCommand",
-                      "uuid": "01836784-ffb5-416a-905b-522ecf3158b7",
-                      "label": ":fsociety: Bundle Audit",
-                      "key": null,
-                      "dependencies": {
-                        "edges": [
-
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "node": {
-                      "__typename": "StepCommand",
-                      "uuid": "01836784-ffb5-40b5-a7a9-f72275552e3f",
-                      "label": ":yarnpkg: Yarn Audit",
-                      "key": null,
-                      "dependencies": {
-                        "edges": [
-
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "node": {
-                      "__typename": "StepCommand",
-                      "uuid": "01836784-ffb6-4c3c-9d1e-54375f53e99c",
-                      "label": ":yarnpkg: Outdated Check",
-                      "key": null,
-                      "dependencies": {
-                        "edges": [
-
-                        ]
-                      }
-                    }
-                  }
-                ]
-              }
-            }
+            },
           },
           {
-            "node": {
-              "__typename": "StepGroup",
-              "uuid": "01836784-ffb6-4d22-a76b-b5832d313d8e",
-              "label": ":face_with_open_eyes_and_hand_over_mouth::graphql: API Verification",
-              "key": "api_verification",
-              "dependencies": {
-                "edges": [
+            node: {
+              __typename: "StepGroup",
+              uuid: "01836784-ffb2-4e03-8797-5971abf7b4dd",
+              label: ":broom: Linting",
+              key: "linting",
+              dependencies: {
+                edges: [
                   {
-                    "node": {
-                      "uuid": "18d41d1d-5c55-4f39-8dd5-0d98a59c35d6",
-                      "allow_failure": false,
-                      "key": "docker"
-                    }
-                  }
-                ]
+                    node: {
+                      uuid: "ee5e5367-df13-4b02-8118-c3c28d54cd7a",
+                      allow_failure: false,
+                      key: "docker",
+                    },
+                  },
+                ],
               },
-              "steps": {
-                "edges": [
+              steps: {
+                edges: [
                   {
-                    "node": {
-                      "__typename": "StepCommand",
-                      "uuid": "01836784-ffb6-4744-a8b2-c17e4f5be408",
-                      "label": ":graphql: GraphQL",
-                      "key": null,
-                      "dependencies": {
-                        "edges": [
-
-                        ]
-                      }
-                    }
-                  }
-                ]
-              }
-            }
+                    node: {
+                      __typename: "StepCommand",
+                      uuid: "01836784-ffb2-4d4e-8ae8-3b9191403a0f",
+                      label: ":rubocop: RuboCop",
+                      key: null,
+                      dependencies: {
+                        edges: [],
+                      },
+                    },
+                  },
+                  {
+                    node: {
+                      __typename: "StepCommand",
+                      uuid: "01836784-ffb3-4d2e-8af1-f9c8ddb60b20",
+                      label: ":eslint: ESlint",
+                      key: null,
+                      dependencies: {
+                        edges: [],
+                      },
+                    },
+                  },
+                  {
+                    node: {
+                      __typename: "StepCommand",
+                      uuid: "01836784-ffb3-4c5d-b540-b1b0bc04f672",
+                      label: ":flowtype: Flow",
+                      key: null,
+                      dependencies: {
+                        edges: [],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
           },
           {
-            "node": {
-              "__typename": "StepGroup",
-              "uuid": "01836784-ffb7-4433-bee6-4766b12748d1",
-              "label": ":rspec: RSpec",
-              "key": "rspec",
-              "dependencies": {
-                "edges": [
+            node: {
+              __typename: "StepGroup",
+              uuid: "01836784-ffb4-4f78-b23c-0779ee1c61f7",
+              label: ":lock_with_ink_pen: Security Audits",
+              key: "security_audits",
+              dependencies: {
+                edges: [
                   {
-                    "node": {
-                      "uuid": "a0b6a59a-defe-43cd-8881-1c92940af95f",
-                      "allow_failure": false,
-                      "key": "docker"
-                    }
-                  }
-                ]
+                    node: {
+                      uuid: "ecff6fbe-aabf-4d2e-a125-d76047c4e007",
+                      allow_failure: false,
+                      key: "docker",
+                    },
+                  },
+                ],
               },
-              "steps": {
-                "edges": [
+              steps: {
+                edges: [
                   {
-                    "node": {
-                      "__typename": "StepCommand",
-                      "uuid": "01836784-ffb7-477e-b1dc-972b3d059516",
-                      "label": ":mag: Discover",
-                      "key": "rspec_discover",
-                      "dependencies": {
-                        "edges": [
-
-                        ]
-                      }
-                    }
+                    node: {
+                      __typename: "StepCommand",
+                      uuid: "01836784-ffb4-45d0-8a95-1f51477e1c8a",
+                      label: ":brakeman: Brakeman",
+                      key: null,
+                      dependencies: {
+                        edges: [],
+                      },
+                    },
                   },
                   {
-                    "node": {
-                      "__typename": "StepCommand",
-                      "uuid": "01836784-ffb7-4b3c-91ab-bfe5268deb54",
-                      "label": ":rspec: Run",
-                      "key": "rspec_run",
-                      "dependencies": {
-                        "edges": [
-
-                        ]
-                      }
-                    }
+                    node: {
+                      __typename: "StepCommand",
+                      uuid: "01836784-ffb5-416a-905b-522ecf3158b7",
+                      label: ":fsociety: Bundle Audit",
+                      key: null,
+                      dependencies: {
+                        edges: [],
+                      },
+                    },
                   },
                   {
-                    "node": {
-                      "__typename": "StepCommand",
-                      "uuid": "01836784-ffb8-4084-b509-f7a90df93142",
-                      "label": ":clipboard: Verify",
-                      "key": "rspec_verify",
-                      "dependencies": {
-                        "edges": [
+                    node: {
+                      __typename: "StepCommand",
+                      uuid: "01836784-ffb5-40b5-a7a9-f72275552e3f",
+                      label: ":yarnpkg: Yarn Audit",
+                      key: null,
+                      dependencies: {
+                        edges: [],
+                      },
+                    },
+                  },
+                  {
+                    node: {
+                      __typename: "StepCommand",
+                      uuid: "01836784-ffb6-4c3c-9d1e-54375f53e99c",
+                      label: ":yarnpkg: Outdated Check",
+                      key: null,
+                      dependencies: {
+                        edges: [],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          {
+            node: {
+              __typename: "StepGroup",
+              uuid: "01836784-ffb6-4d22-a76b-b5832d313d8e",
+              label:
+                ":face_with_open_eyes_and_hand_over_mouth::graphql: API Verification",
+              key: "api_verification",
+              dependencies: {
+                edges: [
+                  {
+                    node: {
+                      uuid: "18d41d1d-5c55-4f39-8dd5-0d98a59c35d6",
+                      allow_failure: false,
+                      key: "docker",
+                    },
+                  },
+                ],
+              },
+              steps: {
+                edges: [
+                  {
+                    node: {
+                      __typename: "StepCommand",
+                      uuid: "01836784-ffb6-4744-a8b2-c17e4f5be408",
+                      label: ":graphql: GraphQL",
+                      key: null,
+                      dependencies: {
+                        edges: [],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          {
+            node: {
+              __typename: "StepGroup",
+              uuid: "01836784-ffb7-4433-bee6-4766b12748d1",
+              label: ":rspec: RSpec",
+              key: "rspec",
+              dependencies: {
+                edges: [
+                  {
+                    node: {
+                      uuid: "a0b6a59a-defe-43cd-8881-1c92940af95f",
+                      allow_failure: false,
+                      key: "docker",
+                    },
+                  },
+                ],
+              },
+              steps: {
+                edges: [
+                  {
+                    node: {
+                      __typename: "StepCommand",
+                      uuid: "01836784-ffb7-477e-b1dc-972b3d059516",
+                      label: ":mag: Discover",
+                      key: "rspec_discover",
+                      dependencies: {
+                        edges: [],
+                      },
+                    },
+                  },
+                  {
+                    node: {
+                      __typename: "StepCommand",
+                      uuid: "01836784-ffb7-4b3c-91ab-bfe5268deb54",
+                      label: ":rspec: Run",
+                      key: "rspec_run",
+                      dependencies: {
+                        edges: [],
+                      },
+                    },
+                  },
+                  {
+                    node: {
+                      __typename: "StepCommand",
+                      uuid: "01836784-ffb8-4084-b509-f7a90df93142",
+                      label: ":clipboard: Verify",
+                      key: "rspec_verify",
+                      dependencies: {
+                        edges: [
                           {
-                            "node": {
-                              "uuid": "d65db9c1-e987-40b3-b65f-758c5a01feaa",
-                              "allow_failure": false,
-                              "key": "rspec_run"
-                            }
+                            node: {
+                              uuid: "d65db9c1-e987-40b3-b65f-758c5a01feaa",
+                              allow_failure: false,
+                              key: "rspec_run",
+                            },
                           },
                           {
-                            "node": {
-                              "uuid": "296d3fcf-0354-4e5a-8114-6e11ea1b55be",
-                              "allow_failure": false,
-                              "key": "rspec_discover"
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  }
-                ]
-              }
-            }
+                            node: {
+                              uuid: "296d3fcf-0354-4e5a-8114-6e11ea1b55be",
+                              allow_failure: false,
+                              key: "rspec_discover",
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
           },
           {
-            "node": {
-              "__typename": "StepCommand",
-              "uuid": "01836784-ffb8-4abb-bb57-241fc5250fb4",
-              "label": ":jest: Jest",
-              "key": "jest",
-              "dependencies": {
-                "edges": [
+            node: {
+              __typename: "StepCommand",
+              uuid: "01836784-ffb8-4abb-bb57-241fc5250fb4",
+              label: ":jest: Jest",
+              key: "jest",
+              dependencies: {
+                edges: [
                   {
-                    "node": {
-                      "uuid": "5bcd49da-3fa9-4a11-8262-f5527e6316b8",
-                      "allow_failure": false,
-                      "key": "docker"
-                    }
-                  }
-                ]
-              }
-            }
+                    node: {
+                      uuid: "5bcd49da-3fa9-4a11-8262-f5527e6316b8",
+                      allow_failure: false,
+                      key: "docker",
+                    },
+                  },
+                ],
+              },
+            },
           },
           {
-            "node": {
-              "__typename": "StepCommand",
-              "uuid": "01836784-ffb9-4d9a-853e-14cb7b9d8a2a",
-              "label": ":coverage: Code Coverage",
-              "key": "code_coverage",
-              "dependencies": {
-                "edges": [
+            node: {
+              __typename: "StepCommand",
+              uuid: "01836784-ffb9-4d9a-853e-14cb7b9d8a2a",
+              label: ":coverage: Code Coverage",
+              key: "code_coverage",
+              dependencies: {
+                edges: [
                   {
-                    "node": {
-                      "uuid": "1fe461de-5467-41e8-844a-81dfe991cc3c",
-                      "allow_failure": true,
-                      "key": "rspec_run"
-                    }
-                  }
-                ]
-              }
-            }
+                    node: {
+                      uuid: "1fe461de-5467-41e8-844a-81dfe991cc3c",
+                      allow_failure: true,
+                      key: "rspec_run",
+                    },
+                  },
+                ],
+              },
+            },
           },
           {
-            "node": {
-              "__typename": "StepCommand",
-              "uuid": "01836784-ffba-44db-a905-7789e34d0902",
-              "label": ":webpack: Bundle Analysis",
-              "key": "bundle_analysis",
-              "dependencies": {
-                "edges": [
+            node: {
+              __typename: "StepCommand",
+              uuid: "01836784-ffba-44db-a905-7789e34d0902",
+              label: ":webpack: Bundle Analysis",
+              key: "bundle_analysis",
+              dependencies: {
+                edges: [
                   {
-                    "node": {
-                      "uuid": "60cd0e1c-e451-461b-b123-06482bad07d6",
-                      "allow_failure": false,
-                      "key": "docker"
-                    }
-                  }
-                ]
-              }
-            }
+                    node: {
+                      uuid: "60cd0e1c-e451-461b-b123-06482bad07d6",
+                      allow_failure: false,
+                      key: "docker",
+                    },
+                  },
+                ],
+              },
+            },
           },
           {
-            "node": {
-              "__typename": "StepTrigger",
-              "uuid": "01836784-ffba-429c-9b20-13dc0207e6dd",
-              "label": ":rocket: Deploy to Production",
-              "key": "deploy",
-              "dependencies": {
-                "edges": [
+            node: {
+              __typename: "StepTrigger",
+              uuid: "01836784-ffba-429c-9b20-13dc0207e6dd",
+              label: ":rocket: Deploy to Production",
+              key: "deploy",
+              dependencies: {
+                edges: [
                   {
-                    "node": {
-                      "uuid": "e191c2ab-e9a9-4830-9ef6-4665464b15d5",
-                      "allow_failure": false,
-                      "key": "jest"
-                    }
+                    node: {
+                      uuid: "e191c2ab-e9a9-4830-9ef6-4665464b15d5",
+                      allow_failure: false,
+                      key: "jest",
+                    },
                   },
                   {
-                    "node": {
-                      "uuid": "ab10ba92-cd11-494d-812e-7c70bc0adf1d",
-                      "allow_failure": false,
-                      "key": "rspec"
-                    }
+                    node: {
+                      uuid: "ab10ba92-cd11-494d-812e-7c70bc0adf1d",
+                      allow_failure: false,
+                      key: "rspec",
+                    },
                   },
                   {
-                    "node": {
-                      "uuid": "7076b654-6229-4dd7-a1aa-2bcc1fc0c5a8",
-                      "allow_failure": false,
-                      "key": "security_audits"
-                    }
+                    node: {
+                      uuid: "7076b654-6229-4dd7-a1aa-2bcc1fc0c5a8",
+                      allow_failure: false,
+                      key: "security_audits",
+                    },
                   },
                   {
-                    "node": {
-                      "uuid": "da341fc9-1fb7-4f3f-9ddd-7ae02c06c3f2",
-                      "allow_failure": false,
-                      "key": "linting"
-                    }
-                  }
-                ]
-              }
-            }
-          }
-        ]
-      }
+                    node: {
+                      uuid: "da341fc9-1fb7-4f3f-9ddd-7ae02c06c3f2",
+                      allow_failure: false,
+                      key: "linting",
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+};
+
+function buildEmojiLookupTable(json) {
+  var emojis = {};
+
+  json.forEach(function (emoji) {
+    emojis[emoji.name] = emoji.url;
+
+    if (emoji.aliases) {
+      emoji.aliases.forEach(function (alias) {
+        emojis[alias] = emoji.url;
+      });
     }
-  }
+  });
+
+  return emojis;
 }
 
 export async function getServerSideProps(context) {
-  let roomId = context.query['room'];
-  if (roomId === null || roomId === undefined || (roomId && roomId.trim() === "")) {
+  let roomId = context.query["room"];
+  if (
+    roomId === null ||
+    roomId === undefined ||
+    (roomId && roomId.trim() === "")
+  ) {
     roomId = "default";
   }
 
-  const res = await fetch(`https://api.liveblocks.io/v2/rooms/${encodeURIComponent(roomId)}/storage`, {
-    headers: { Authorization: `Bearer ${process.env.LIVEBLOCKS_PRIVATE_KEY}` }
-  });
-  const json = await res.json()
+  const res = await fetch(
+    `https://api.liveblocks.io/v2/rooms/${encodeURIComponent(roomId)}/storage`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.LIVEBLOCKS_PRIVATE_KEY}`,
+      },
+    }
+  );
+  const json = await res.json();
 
-  return { props: { roomId, build: response.data.build } };
+  const emoji_res = await fetch(
+    `https://api.buildkite.com/v2/organizations/${process.env.BUILDKITE_ORG}/emojis?access_token=${process.env.BUILDKITE_ACCESS_TOKEN}`
+  );
+  const emoji_json = await emoji_res.json();
+  const emoji = buildEmojiLookupTable(emoji_json);
+
+  return { props: { roomId, build: response.data.build, emoji } };
 }
 
-export default function Home({ roomId, build }) {
-  const { nodes, edges } = generateGraphFromBuildSteps(build.steps)
+export default function Home({ roomId, build, emoji }) {
+  const { nodes, edges } = generateGraphFromBuildSteps(build.steps);
 
   return (
     <div className={styles.container}>
       <Head>
         <title>🎮</title>
       </Head>
-
-      <ThemeSwitch />
-      <Flow roomId={roomId} initialNodes={nodes} initialEdges={edges} />
+      <EmojiContext.Provider value={emoji}>
+        <ThemeSwitch />
+        <Flow roomId={roomId} initialNodes={nodes} initialEdges={edges} />
+      </EmojiContext.Provider>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
A proof of concept implementation of Buildkite’s emoji API.

Currently this is achieved by fetching the emoji available for a given user, and then surfacing that emoji object in a React context provider, which a `<Label>` component consumes to replace any matched emoji codes with an `<img>` tag and the corresponding `src` path hosted by Buildkite ([hat tip to Tim for some prior-art](https://codepen.io/toolmantim/pen/xbQRaL/)).

It also implements theme tweaks to adjust the appearance of the dot grid background, and other UI elements between light and dark mode:

https://user-images.githubusercontent.com/677025/201848162-54159385-d775-4bdf-994d-ad2d05aca2a0.mp4

With this implementation, note that next.js complains about the emoji object data payload:

> Warning: data for page "/" is 202 kB which exceeds the threshold of
> 128 kB, this amount of data can reduce performance. See more info
> here: https://nextjs.org/docs/messages/large-page-data

In order to run this, add your org slug and buildkite token to `.env.local`:
```bash
BUILDKITE_ORG=your-org-slug
BUILDKITE_ACCESS_TOKEN=account-access-token
```